### PR TITLE
ExecutablesDB: require "cmd/tap" for install_tap

### DIFF
--- a/cmd/brew-which-update.rb
+++ b/cmd/brew-which-update.rb
@@ -11,6 +11,7 @@
 require "formula"
 require "pathname"
 require "set"
+require "cmd/tap"
 
 # ExecutablesDB represents a DB associating formulae to the binaries they
 # provide.


### PR DESCRIPTION
Closes Homebrew/homebrew-command-not-found#31.
